### PR TITLE
Issue 100

### DIFF
--- a/asset/js/add-team-to-resource.js
+++ b/asset/js/add-team-to-resource.js
@@ -22,13 +22,40 @@ $(document).ready(function() {
     });
 
 // Remove a team from the edit panel.
-    $('#team-resources').on('click', '.o-icon-delete', function(event) {
+    $('#team-resources').on('click', '.o-icon-delete.existing', function(event) {
+        event.preventDefault();
+
+        var removeLink = $(this);
+        var teamRow = $(this).closest('tr');
+        var teamInput = removeLink.closest('tr').find('input');
+        teamInput.attr('name', 'remove_team[]')
+
+        // Undo remove team link.
+        var undoRemoveLink = $('<a>', {
+            href: '#',
+            class: 'fa fa-undo',
+            title: Omeka.jsTranslate('Undo remove team'),
+            click: function(event) {
+                event.preventDefault();
+                teamInput.attr('name', 'existing_team[]');
+                teamRow.toggleClass('delete');
+                removeLink.show();
+                $(this).remove();
+            },
+        });
+
+        teamRow.toggleClass('delete');
+        undoRemoveLink.insertAfter(removeLink);
+            removeLink.hide();
+    });
+    $('#team-resources').on('click', '.o-icon-delete.new', function(event) {
         event.preventDefault();
 
         var removeLink = $(this);
         var teamRow = $(this).closest('tr');
         var teamInput = removeLink.closest('tr').find('input');
         teamInput.prop('disabled', true);
+
 
         // Undo remove team link.
         var undoRemoveLink = $('<a>', {

--- a/src/Mvc/Controller/Plugin/TeamAuth.php
+++ b/src/Mvc/Controller/Plugin/TeamAuth.php
@@ -4,6 +4,7 @@ namespace Teams\Mvc\Controller\Plugin;
 use Doctrine\ORM\EntityManager;
 use InvalidArgumentException;
 use Laminas\Mvc\Controller\Plugin\AbstractPlugin;
+use \Omeka\Entity\User;
 
 /**
  * Controller plugin for authorize the current user.
@@ -19,31 +20,33 @@ class TeamAuth extends AbstractPlugin
     protected $entityManager;
 
     /**
+     * @var \Omeka\Entity\User
+     */
+    protected $user;
+
+    /**
      * Construct the plugin.
      *
      * @param EntityManager $entityManager
      */
-    public function __construct(EntityManager $entityManager)
+    public function __construct(EntityManager $entityManager, User $user)
     {
         $this->entityManager = $entityManager;
+        $this->user = $user;
     }
 
-    public function user()
-    {
-        return $this->getController()->identity();
-    }
 
     public function isGlobAdmin()
     {
-        return $this->user()->getRole() === 'global_admin';
+        return $this->user->getRole() === 'global_admin';
     }
 
     public function isSuper()
     {
-        return ($this->isGlobAdmin() && $this->user()->getId() === 1);
+        return ($this->isGlobAdmin() && $this->user->getId() === 1);
     }
 
-    public function teamAuthorized(string $action, string $domain)
+    public function teamAuthorized(string $action, string $domain, int $context=0): bool
     {
         //validate inputs
         if (!in_array($action, $this->actions)) {
@@ -69,7 +72,7 @@ class TeamAuth extends AbstractPlugin
         }
 
         $em = $this->entityManager;
-        $user_id = $this->user()->getId();
+        $user_id = $this->user->getId();
         $authorized = false;
 
 

--- a/src/View/Helper/RoleAuth.php
+++ b/src/View/Helper/RoleAuth.php
@@ -37,7 +37,7 @@ class RoleAuth extends AbstractHelper
         return ($this->isGlobAdmin() && $this->user()->getId() === 1);
     }
 
-    public function teamAuthorized(string $action, string $domain)
+    public function teamAuthorized(string $action, string $domain, int $context=0)
     {
         //validate inputs
         if (!in_array($action, $this->actions)) {
@@ -67,10 +67,21 @@ class RoleAuth extends AbstractHelper
         $authorized = false;
 
 
+        if ($context > 0) {
+            //determine if the user is part of that team
+            $has_role = $em->getRepository('Teams\Entity\TeamUser')
+            ->findOneBy(['user' => $user_id, 'team'=>$context]);
+
+        } else {
+            //get the users current team
+            $has_role = $em->getRepository('Teams\Entity\TeamUser')
+                ->findOneBy(['is_current' => true, 'user'=>$user_id]);
+        }
+
+
+
         //if the user has a current team
-        if ($has_role = $em->getRepository('Teams\Entity\TeamUser')
-            ->findOneBy(['is_current' => true, 'user'=>$user_id])
-            ) {
+        if ($has_role) {
             $current_role = $has_role->getRole();
 
             //go through each domain and determine if user is authorized for actions in that domain

--- a/view/teams/partial/add-team.phtml
+++ b/view/teams/partial/add-team.phtml
@@ -6,7 +6,7 @@ $teamsByInitial = [];
 $totalCount = 0;
 foreach ($this->teams as $team) {
     if ($this->roleAuth()->teamAuthorized('add', 'resource', $team->id())) {
-        $teamCount+=1;
+        $totalCount+=1;
         if (extension_loaded('mbstring')) {
             $initial = mb_substr($team->name(), 0, 1);
             $teamsByInitial[mb_strtolower($initial)][] = $team;

--- a/view/teams/partial/add-team.phtml
+++ b/view/teams/partial/add-team.phtml
@@ -3,8 +3,10 @@ $escape = $this->plugin('escapeHtml');
 
 // Teams are already sorted.
 $teamsByInitial = [];
+$teamCount = 0;
 foreach ($this->teams as $team) {
     if ($this->roleAuth()->teamAuthorized('add', 'resource', $team->id())) {
+        $teamCount+=1;
         if (extension_loaded('mbstring')) {
             $initial = mb_substr($team->name(), 0, 1);
             $teamsByInitial[mb_strtolower($initial)][] = $team;
@@ -21,7 +23,7 @@ foreach ($this->teams as $team) {
     <h3><?php echo $this->translate('Click on a team to add it to the edit panel.'); ?></h3>
     <input type="text" class="selector-filter" placeholder="<?php echo $escape($this->translate('Filter teams')); ?>">
     <ul>
-        <li class="total-count-heading"><?php echo $this->translate('All teams'); ?> (<span class="selector-total-count"><?php echo count($teams); ?></span>)
+        <li class="total-count-heading"><?php echo $this->translate('All teams'); ?> (<span class="selector-total-count"><?php echo $teamCount; ?></span>)
             <ul class="selectable-list">
                 <?php foreach ($teamsByInitial as $initial => $teams): ?>
                 <li class="selector-parent">

--- a/view/teams/partial/add-team.phtml
+++ b/view/teams/partial/add-team.phtml
@@ -3,7 +3,7 @@ $escape = $this->plugin('escapeHtml');
 
 // Teams are already sorted.
 $teamsByInitial = [];
-$teamCount = 0;
+$totalCount = 0;
 foreach ($this->teams as $team) {
     if ($this->roleAuth()->teamAuthorized('add', 'resource', $team->id())) {
         $teamCount+=1;
@@ -23,7 +23,7 @@ foreach ($this->teams as $team) {
     <h3><?php echo $this->translate('Click on a team to add it to the edit panel.'); ?></h3>
     <input type="text" class="selector-filter" placeholder="<?php echo $escape($this->translate('Filter teams')); ?>">
     <ul>
-        <li class="total-count-heading"><?php echo $this->translate('All teams'); ?> (<span class="selector-total-count"><?php echo $teamCount; ?></span>)
+        <li class="total-count-heading"><?php echo $this->translate('All teams'); ?> (<span class="selector-total-count"><?php echo $totalCount; ?></span>)
             <ul class="selectable-list">
                 <?php foreach ($teamsByInitial as $initial => $teams): ?>
                 <li class="selector-parent">

--- a/view/teams/partial/add-team.phtml
+++ b/view/teams/partial/add-team.phtml
@@ -3,17 +3,18 @@ $escape = $this->plugin('escapeHtml');
 
 // Teams are already sorted.
 $teamsByInitial = [];
-if (extension_loaded('mbstring')) {
-    foreach ($teams as $team) {
-        $initial = mb_substr($team->name(), 0, 1);
-        $teamsByInitial[mb_strtolower($initial)][] = $team;
-    }
-} else {
-    foreach ($teams as $team) {
-        $initial = substr($team->name(), 0, 1);
-        $teamsByInitial[strtolower($initial)][] = $team;
+foreach ($this->teams as $team) {
+    if ($this->roleAuth()->teamAuthorized('add', 'resource', $team->id())) {
+        if (extension_loaded('mbstring')) {
+            $initial = mb_substr($team->name(), 0, 1);
+            $teamsByInitial[mb_strtolower($initial)][] = $team;
+        } else {
+            $initial = substr($team->name(), 0, 1);
+            $teamsByInitial[strtolower($initial)][] = $team;
+        }
     }
 }
+
 ?>
 <div id="team-selector" class='selector sidebar active'>
     <a href="#" class="mobile-only sidebar-close o-icon-close"><span class="screen-reader-text"><?php echo $this->translate('Close Me'); ?></span></a>

--- a/view/teams/partial/team-form-no-id.phtml
+++ b/view/teams/partial/team-form-no-id.phtml
@@ -44,8 +44,9 @@ $teamTemplate = '
                     <td>
                         <ul class="actions" style="float:right">
                             <li>
-
-                                <a href="#" class="o-icon-delete" title="<?php echo $removeStr; ?>" aria-label="<?php echo $removeStr; ?>"></a>
+                                <?php if ($this->roleAuth()->teamAuthorized('delete', 'resource',$team->getId())): ?>
+                                    <a href="#" class="o-icon-delete" title="<?php echo $removeStr; ?>" aria-label="<?php echo $removeStr; ?>"></a>
+                                <?php endif; ?>
                             </li>
                         </ul>
                     </td>
@@ -60,21 +61,6 @@ $teamTemplate = '
 
         </tbody>
     </table>
-    <!--    --><?// else:
-    //        ?>
-    <!--        <div class="no-resources">-->
-    <!--            <p>-->
-    <!--                --><?php //echo $this->translate('There are no teams for this resource.');?>
-    <!--                <br />-->
-    <!--                --><?php //echo $this->translate('Add existing teams using the interface to the right.');?>
-    <!--            </p>-->
-    <!--        </div>-->
-    <!---->
-    <!---->
-    <!---->
-    <!--    --><?php //endif;?>
-
-
     <button id="team-selector-button" class="mobile-only"><?php echo $this->translate('Add a team'); ?></button>
     <span id="team-template" data-template="<?php echo $escape($teamTemplate); ?>"></span>
     <?php echo $this->addTeam(); ?>

--- a/view/teams/partial/team-form.phtml
+++ b/view/teams/partial/team-form.phtml
@@ -12,10 +12,10 @@ $teamTemplate = '
     <td>
         <ul class="actions">
             <li>
-                <a href="#" class="o-icon-delete disabled" title="' . $removeStr . '" aria-label="' . $removeStr . '"></a>
+                <a href="#" class="o-icon-delete new" title="' . $removeStr . '" aria-label="' . $removeStr . '"></a>
             </li>
         </ul>
-        <input type="hidden" name="team[]">
+        <input type="hidden" name="add_team[]">
     </td>
 </tr>';
 ?>
@@ -40,13 +40,13 @@ $teamTemplate = '
                 <td>
                     <span><?php echo $team->getName()?></span>
 
-                    <input type="hidden" name="team[]" value="<?php echo $escape($team->getId()) ?>">
+                    <input type="hidden" name="existing_team[]" value="<?php echo $escape($team->getId()) ?>">
                 </td>
                 <td>
                     <ul class="actions" style="float:right">
                         <li>
                             <?php if ($this->roleAuth()->teamAuthorized('delete', 'resource',$team->getId())): ?>
-                                <a href="#" class="o-icon-delete" title="<?php echo $removeStr; ?>" aria-label="<?php echo $removeStr; ?>"></a>
+                                <a href="#" class="o-icon-delete existing" title="<?php echo $removeStr; ?>" aria-label="<?php echo $removeStr; ?>"></a>
                             <?php endif; ?>
                         </li>
                     </ul>
@@ -73,5 +73,6 @@ $teamTemplate = '
     <?php endif; ?>
     <button id="team-selector-button" class="mobile-only"><?php echo $this->translate('Add a team'); ?></button>
     <span id="team-template" data-template="<?php echo $escape($teamTemplate); ?>"></span>
-    <?php echo $this->addTeam(); ?>
+
+    <?php echo $this->addTeam(); //add the right sidebar control with the list of teams that can be added?>
 </fieldset>

--- a/view/teams/partial/team-form.phtml
+++ b/view/teams/partial/team-form.phtml
@@ -12,7 +12,7 @@ $teamTemplate = '
     <td>
         <ul class="actions">
             <li>
-                <a href="#" class="o-icon-delete" title="' . $removeStr . '" aria-label="' . $removeStr . '"></a>
+                <a href="#" class="o-icon-delete disabled" title="' . $removeStr . '" aria-label="' . $removeStr . '"></a>
             </li>
         </ul>
         <input type="hidden" name="team[]">
@@ -45,8 +45,9 @@ $teamTemplate = '
                 <td>
                     <ul class="actions" style="float:right">
                         <li>
-
-                            <a href="#" class="o-icon-delete" title="<?php echo $removeStr; ?>" aria-label="<?php echo $removeStr; ?>"></a>
+                            <?php if ($this->roleAuth()->teamAuthorized('delete', 'resource',$team->getId())): ?>
+                                <a href="#" class="o-icon-delete" title="<?php echo $removeStr; ?>" aria-label="<?php echo $removeStr; ?>"></a>
+                            <?php endif; ?>
                         </li>
                     </ul>
                 </td>


### PR DESCRIPTION
This fixes #100 by updating the UX so that users only see add/remove options for teams where they have the authority to add or remove items. It then passes add/remove teams as explicit and distinct arrays and the users authority to add/remove is checked for each one before adding/removing the `TeamResource`. 