### PR TITLE
Don't show site options on edit form

### DIFF
--- a/asset/js/hide-unavailable-sites.js
+++ b/asset/js/hide-unavailable-sites.js
@@ -1,0 +1,14 @@
+$(document).ready(function() {
+
+    //remove any empty cells and any trash icons because items are associated with sites via teams
+    $('table#item-sites tr td span.tablesaw-cell-content').each(function(){ // For each element
+        if( $(this).text().trim() === '' ) {
+            $(this).closest('td').remove(); // if it is empty, it removes it
+        }
+    });
+
+    //remove the side site selector interface
+    $('div#site-selector').empty()
+    $('div#site-selector').append('<h3>Site-Item relationships are Managed by Teams</h3>')
+
+});


### PR DESCRIPTION
This fixes #5 by removing the empty rows and showing a message that item-site relationships are managed by teams