### PR TITLE
Bypass teams filter  team resouce population

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -105,12 +105,14 @@ return [
         'invokables' => [
             'addTeam' => 'Teams\View\Helper\AddTeam',
             'bypassTeamsSelector' => 'Teams\View\Helper\BypassTeamsSortSelector',
-            'teamUserSelector' => 'Teams\View\Helper\teamUserSelector',
+            'allUserSelector' => 'Teams\View\Helper\AllUserSelector',
 
 
         ],
         'factories' => [
             'roleAuth' => Service\ViewHelper\RoleAuthFactory::class,
+            'allUserSelect'  => Service\ViewHelper\AllUserSelectFactory::class,
+
         ]
     ],
     'controllers' => [

--- a/src/Service/ViewHelper/AllUserSelectFactory.php
+++ b/src/Service/ViewHelper/AllUserSelectFactory.php
@@ -1,0 +1,14 @@
+<?php
+namespace Teams\Service\ViewHelper;
+
+use Teams\View\Helper\AllUserSelect;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Interop\Container\ContainerInterface;
+
+class AllUserSelectFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $services, $requestedName, array $options = null)
+    {
+        return new AllUserSelect($services->get('FormElementManager'));
+    }
+}

--- a/src/View/Helper/AllUserSelect.php
+++ b/src/View/Helper/AllUserSelect.php
@@ -1,0 +1,46 @@
+<?php
+namespace Teams\View\Helper;
+
+use Omeka\Form\Element\UserSelect as Select;
+use Laminas\Form\Factory;
+use Laminas\View\Helper\AbstractHelper;
+use Laminas\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * View helper for rendering a select menu containing all users.
+ */
+class AllUserSelect extends AbstractHelper
+{
+    /**
+     * @var ServiceLocatorInterface
+     */
+    protected $formElementManager;
+
+    /**
+     * Construct the helper.
+     *
+     * @param ServiceLocatorInterface $formElementManager
+     */
+    public function __construct(ServiceLocatorInterface $formElementManager)
+    {
+        $this->formElementManager = $formElementManager;
+    }
+
+    /**
+     * Render a select menu containing all users.
+     *
+     * @param array $spec
+     * @return string
+     */
+    public function __invoke(array $spec = [])
+    {
+        $spec['type'] = \Teams\Form\Element\UserSelect::class;
+        if (!isset($spec['options']['empty_option'])) {
+            $spec['options']['empty_option'] = 'Select user…'; // @translate
+        }
+        $spec['options']['query'] = ['bypass_team_filter'=>true];
+        $factory = new Factory($this->formElementManager);
+        $element = $factory->createElement($spec);
+        return $this->getView()->formSelect($element);
+    }
+}

--- a/src/View/Helper/AllUserSelector.php
+++ b/src/View/Helper/AllUserSelector.php
@@ -4,7 +4,7 @@ namespace Teams\View\Helper;
 
 use Laminas\View\Helper\AbstractHelper;
 
-class teamUserSelector extends AbstractHelper
+class allUserSelector extends AbstractHelper
 {
     /**
      * Return the user selector form control.

--- a/view/common/advanced-search/item-sets.phtml
+++ b/view/common/advanced-search/item-sets.phtml
@@ -1,0 +1,84 @@
+<?php
+$translate = $this->plugin('translate');
+// Prepare the item set queries
+$inIds = $query['item_set_id'] ?? [];
+if (!is_array($inIds)) {
+    $inIds = [$inIds];
+}
+$inIds = array_filter($inIds);
+$notInIds = $query['not_item_set_id'] ?? [];
+if (!is_array($notInIds)) {
+    $notInIds = [$notInIds];
+}
+$notInIds = array_filter($notInIds);
+$itemSets = [];
+foreach ($inIds as $inId) {
+    $itemSets[] = ['id' => $inId, 'type' => 'in'];
+}
+foreach ($notInIds as $notInId) {
+    $itemSets[] = ['id' => $notInId, 'type' => 'not_in'];
+}
+if (!$itemSets) {
+    $itemSets[] = ['id' => null, 'type' => 'in'];
+}
+
+if ($this->status()->isSiteRequest()) {
+    if (!$this->layout()->site->siteItemSets()) {
+        return;
+    }
+    $filterLocale = (bool) $this->siteSetting('filter_locale_values');
+    $lang = $this->lang();
+
+    $selectOptions = [
+        'disable_group_by_owner' => true,
+        'query' => ['site_id' => $this->layout()->site->id(), 'bypass_team_filter' => true],
+        'lang' => $filterLocale ? [$lang, ''] : null,
+    ];
+} else {
+    $selectOptions = [
+        'query' => ['bypass_team_filter' => true],
+
+    ];
+}
+?>
+<div id="item-sets" class="field removable multi-value" role="group" aria-labelledby="by-item-set-label">
+    <div class="field-meta">
+        <span id="by-item-set-label" class="label"><?php echo $translate('Search by item set'); ?></span>
+        <?php echo $this->hyperlink('', '#', ['class' => 'expand', 'title' => $translate('Expand')]); ?>
+        <div class="collapsible">
+            <div class="field-description"><?php echo $translate('Searches for items that are assigned to any of these item sets.'); ?></div>
+        </div>
+        <button type="button" class="add-value o-icon-add button" aria-label="<?php echo $translate('Add new item set'); ?>" title="<?php echo $translate('Add new item set'); ?>"></button>
+    </div>
+    <div class="inputs">
+        <?php foreach ($itemSets as $itemSet): ?>
+            <div class="value">
+                <select class="item-set-select-type" aria-label="<?php echo $translate('Condition'); ?>">
+                    <option value="in"<?php echo 'in' === $itemSet['type'] ? ' selected' : ''; ?>><?php echo $translate('In'); ?></option>
+                    <option value="not_in"<?php echo 'not_in' === $itemSet['type'] ? ' selected' : ''; ?>><?php echo $translate('Not in'); ?></option>
+                </select>
+                <?php echo $this->itemSetSelect([
+                    'name' => ('not_in' === $itemSet['type']) ? 'not_item_set_id[]' : 'item_set_id[]',
+                    'attributes' => [
+                        'value' => $itemSet['id'],
+                        'class' => 'item-set-select',
+                        'aria-labelledby' => 'by-item-set-label',
+                    ],
+                    'options' => $selectOptions,
+                ]); ?>
+                <button type="button" class="o-icon-delete remove-value button" aria-label="<?php echo $translate('Remove value'); ?>" title="<?php echo $translate('Remove value'); ?>"></button>
+            </div>
+        <?php endforeach; ?>
+    </div>
+</div>
+<script>
+    $('#content').on('change', '.item-set-select-type', function() {
+        const typeSelect = $(this);
+        const itemSetSelect = typeSelect.closest('.value').find('.item-set-select');
+        if ('not_in' === typeSelect.val()) {
+            itemSetSelect.attr('name', 'not_item_set_id[]');
+        } else {
+            itemSetSelect.attr('name', 'item_set_id[]');
+        }
+    });
+</script>

--- a/view/common/advanced-search/owner.phtml
+++ b/view/common/advanced-search/owner.phtml
@@ -1,0 +1,22 @@
+<div class="field">
+    <div class="field-meta">
+        <label for="owner_id"><?php echo $this->translate('Search by owner'); ?></label>
+        <?php echo $this->hyperlink('', '#', ['class' => 'expand', 'title' => $this->translate('Expand')]); ?>
+        <div class="collapsible">
+            <div class="field-description"><?php echo $this->translate('Searches for resources that are owned by this user.'); ?></div>
+        </div>
+    </div>
+    <div class="inputs">
+        <?php echo $this->allUserSelect([
+            'name' => 'owner_id',
+            'attributes' => [
+                'id' => 'owner_id',
+                'value' => $query['owner_id'] ?? null,
+            ],
+            'options' => [
+                'query' => ['bypass_team_filter' => true]
+            ]
+
+        ]); ?>
+    </div>
+</div>

--- a/view/common/advanced-search/resource-template.phtml
+++ b/view/common/advanced-search/resource-template.phtml
@@ -1,0 +1,40 @@
+<?php
+$translate = $this->plugin('translate');
+
+// Prepare the resource template query.
+$ids = isset($query['resource_template_id']) ? $query['resource_template_id'] : [];
+if (!is_array($ids)) {
+    $ids = [$ids];
+}
+$ids = array_filter($ids);
+if (!$ids) {
+    $ids = [null];
+}
+?>
+<div id="resource-templates" class="field removable multi-value" role="group">
+    <div class="field-meta">
+        <span id="by-resource-template-label" class="label"><?php echo $translate('Search by template'); ?></span>
+        <?php echo $this->hyperlink('', '#', ['class' => 'expand', 'title' => $translate('Expand')]); ?>
+        <div class="collapsible">
+            <div class="field-description"><?php echo $translate('Searches for resources that use any of these templates.'); ?></div>
+        </div>
+        <button type="button" class="add-value o-icon-add button" aria-label="<?php echo $translate('Add new template'); ?>" title="<?php echo $translate('Add new template'); ?>"></button>
+    </div>
+    <div class="inputs">
+        <?php foreach ($ids as $id): ?>
+            <div class="value">
+                <?php echo $this->resourceTemplateSelect([
+                    'name' => 'resource_template_id[]',
+                    'attributes' => [
+                        'value' => $id,
+                        'aria-labelledby' =>  'by-resource-template-label'
+                    ],
+                    'options' => [
+                        'query' => ['bypass_team_filter' => true]
+                    ]
+                ]); ?>
+                <button type="button" class="o-icon-delete remove-value button" aria-label="<?php echo $translate('Remove value'); ?>" title="<?php echo $translate('Remove value'); ?>"></button>
+            </div>
+        <?php endforeach; ?>
+    </div>
+</div>

--- a/view/common/advanced-search/site.phtml
+++ b/view/common/advanced-search/site.phtml
@@ -1,0 +1,22 @@
+<div class="field">
+    <div class="field-meta">
+        <label for="site_id"><?php echo $this->translate('Search by site'); ?></label>
+        <?php echo $this->hyperlink('', '#', ['class' => 'expand', 'title' => $this->translate('Expand')]); ?>
+        <div class="collapsible">
+            <div class="field-description"><?php echo $this->translate('Searches for items that are assigned to this site.'); ?></div>
+        </div>
+    </div>
+    <div class="inputs">
+        <?php echo $this->siteSelect([
+            'name' => 'site_id',
+            'attributes' => [
+                'id' => 'site_id',
+                'value' => $query['site_id'] ?? null,
+            ],
+            'options' => [
+                'query' => ['bypass_team_filter' => true]
+            ]
+
+        ]); ?>
+    </div>
+</div>

--- a/view/teams/team/manage-users.phtml
+++ b/view/teams/team/manage-users.phtml
@@ -53,7 +53,7 @@ if ($team) {
     <p><?php echo $translate('This team has no users. Add users using the interface to the right.'); ?></p>
 </div>
 <button id="site-user-selector-button" class="mobile-only"><?php echo $translate('Add new user'); ?></button>
-<?php echo $this->teamUserSelector($translate('Click on a user to add them to the team.'),true,$this->bypass_teams_filter); ?>
+<?php echo $this->allUserSelector($translate('Click on a user to add them to the team.'),true,$this->bypass_teams_filter); ?>
 
 
 


### PR DESCRIPTION
This fixes #170 by replacing advanced search elements with ones that have the `bypass_team_filter` query parameter. The design of this approach is that the flag is neutered if the user is not authorized to have access to the bypass, so users without this ability will have the same experience with the standard advanced search. 

However, this **does** grant these same expanded options for the regular Advanced Search for users with the authority to bypass team filtering. My feeling is that this is a positive externality and we don't need to do anything additional to maintain the old behavior or the standard advanced search form. 